### PR TITLE
Develop

### DIFF
--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/RichTextEditorMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/RichTextEditorMaker.java
@@ -382,10 +382,15 @@ public class RichTextEditorMaker extends AbstractWidgetMaker {
 				styleParameters.setText(stylesAnnotation.styles()[i].text());
 				styleList.add(new RteStyle(styleParameters));
 			}
+			WidgetCollectionParameters wcp = new WidgetCollectionParameters();
+			wcp.setContainedElements(styleList);
+			wcp.setFieldName("styles");
+
+			List<DialogElement> stylesDialogElements = Arrays.asList(new DialogElement[] { new WidgetCollection(wcp) });
 			RtePluginParameters widgetParameters = new RtePluginParameters();
 			widgetParameters.setFieldName("styles");
 			widgetParameters.setFeatures(ALL_FEATURES);
-			widgetParameters.setContainedElements(styleList);
+			widgetParameters.setContainedElements(stylesDialogElements);
 			return new RtePlugin(widgetParameters);
 		}
 


### PR DESCRIPTION
First of all, thanks for developing this awesome plugin. I love the annotations driven generation of all of the XML files for CQ content components.

I was trying to create a richtext editor with a custom Styles list, and that's when I encountered the bug. The `private RtePlugin buildStylesRtePlugin(RichTextEditor rteAnnotation)` method was outputting the styles under a node named "spellcheck", and the expected WidgetCollection sub node named `styles` was also missing. The output was like the following block, which CQ didn't interpret correctly as a Styles drop down menu:

```
spellcheck(jcr:primaryType(Name)=nt:unstructured, features(String)=*)
   ->style0
   ->...
   ->styleN
```

After the fix I'm requesting you pull into your code, the output in CQ will be as follows:

```
styles(jcr:primaryType(Name)=nt:unstructured, features(String)=*)
   ->styles(jcr:primaryType(Name)=cq:WidgetCollection)
      ->style0
      ->...
      ->styleN
```
