### PR TITLE
Fix the README Maven Site Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ cq-component-maven-plugin
 The CQ Component Plugin generates many of the artifacts necessary for the creation of a CQ Component based on the information provided
 by the Component's backing Java Class.
 
-For more information on the Plugin and its usage, please see the [CQ Component Plugin site]("http://code.citytechinc.com/cq-component-maven-plugin/index.html)
+For more information on the Plugin and its usage, please see the [CQ Component Plugin site](http://code.citytechinc.com/cq-component-maven-plugin/)
 


### PR DESCRIPTION
The markdown code contained an erroneous quotation mark and ended in index.html, which is unnecessary. The quotation mark was causing the link to have no destination when viewed through GitHub's web interface.
